### PR TITLE
Remove Slot enum

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -2,7 +2,7 @@
 pub enum Op {
     Gen(usize, Vec<usize>),
     Call(usize, Vec<usize>),
-    ReturnSlot(usize), // TODO ReturnLocal
+    ReturnLocal(usize), 
     Return,
     Branch(usize),
     DynCall(Vec<usize>),

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,17 +1,12 @@
 
-pub enum Slot { 
-    Local(usize),
-    Return,
-}
-
 pub enum Op {
     Gen(usize, Vec<usize>),
-    Call(usize, Vec<Slot>),
-    ReturnSlot(Slot),
+    Call(usize, Vec<usize>),
+    ReturnSlot(usize), // TODO ReturnLocal
     Return,
     Branch(usize),
-    DynCall(Vec<Slot>),
-    Yield(Slot),
+    DynCall(Vec<usize>),
+    Yield(usize),
     Finish,
     Resume(usize),
     FinishSetBranch(usize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ impl<T : Clone, S> Vm<T, S> {
                     fun_stack.push(RetAddr { fun, instr: ip });
                     return Err(VmError::DynFunDoesNotExist(stack_trace(fun_stack, &self.funs)));
                 },
-                Op::ReturnSlot(slot) => {
+                Op::ReturnLocal(slot) => {
                     coroutines.pop().unwrap();
                     let current_locals = locals.pop().unwrap();
 

--- a/tests/branch.rs
+++ b/tests/branch.rs
@@ -33,15 +33,15 @@ fn should_branch() {
             Op::Gen(S, vec![]), 
             Op::Branch(4),         
             Op::Gen(P, vec![0]),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
 
             Op::Gen(U, vec![]),
             Op::Branch(8),         
             Op::Gen(P, vec![1]),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
 
             Op::Gen(P, vec![0]),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -88,7 +88,7 @@ fn should_loop() {
             Op::Drop(3),
             Op::Gen(SET, vec![]),
             Op::Branch(3), 
-            Op::ReturnSlot(Slot::Local(1)),
+            Op::ReturnSlot(1),
         ],
     };
 
@@ -111,7 +111,7 @@ fn should_not_branch_on_active_coroutine() {
         name: "co".into(),
         instrs: vec![
             Op::Gen(0, vec![0]),
-            Op::Yield(Slot::Local(0)),
+            Op::Yield(0),
             Op::Finish,
         ],
     };
@@ -124,7 +124,7 @@ fn should_not_branch_on_active_coroutine() {
             Op::Branch(4),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -158,7 +158,7 @@ fn should_branch_on_finished_coroutine() {
             Op::Branch(4),
             Op::Gen(0, vec![0]),
             Op::Gen(0, vec![1]),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -181,7 +181,7 @@ fn should_branch_on_finished_coroutine_with_active_coroutine_present() {
         name: "co".into(),
         instrs: vec![
             Op::Gen(0, vec![0]),
-            Op::Yield(Slot::Local(0)),
+            Op::Yield(0),
             Op::Finish,
         ],
     };
@@ -196,7 +196,7 @@ fn should_branch_on_finished_coroutine_with_active_coroutine_present() {
             Op::Branch(6),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -219,7 +219,7 @@ fn should_branch_on_finished_coroutine_in_function_where_parent_has_active_corou
         name: "co".into(),
         instrs: vec![
             Op::Gen(0, vec![0]),
-            Op::Yield(Slot::Local(0)),
+            Op::Yield(0),
             Op::Finish,
         ],
     };
@@ -233,7 +233,7 @@ fn should_branch_on_finished_coroutine_in_function_where_parent_has_active_corou
             Op::Branch(5),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -242,7 +242,8 @@ fn should_branch_on_finished_coroutine_in_function_where_parent_has_active_corou
         instrs: vec![
             Op::Call(2, vec![]),
             Op::Call(1, vec![]),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -266,7 +267,7 @@ fn should_branch_on_finished_coroutine_in_dyn_function_where_parent_has_active_c
         name: "co".into(),
         instrs: vec![
             Op::Gen(0, vec![0]),
-            Op::Yield(Slot::Local(0)),
+            Op::Yield(0),
             Op::Finish,
         ],
     };
@@ -280,7 +281,7 @@ fn should_branch_on_finished_coroutine_in_dyn_function_where_parent_has_active_c
             Op::Branch(5),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -292,7 +293,8 @@ fn should_branch_on_finished_coroutine_in_dyn_function_where_parent_has_active_c
             Op::Gen(1, vec![0]),
             Op::DynCall(vec![]),
             Op::Call(1, vec![]),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(1),
         ],
     };
 
@@ -315,7 +317,7 @@ fn should_branch_on_finished_coroutine_in_resumed_coroutine_where_parent_has_act
         name: "co".into(),
         instrs: vec![
             Op::Gen(0, vec![0]),
-            Op::Yield(Slot::Local(0)),
+            Op::Yield(0),
             Op::Finish,
         ],
     };
@@ -325,13 +327,13 @@ fn should_branch_on_finished_coroutine_in_resumed_coroutine_where_parent_has_act
         instrs: vec![
             Op::Call(2, vec![]),
             Op::Gen(0, vec![0]),
-            Op::Yield(Slot::Local(0)),
+            Op::Yield(0),
             Op::Resume(0),
             Op::FinishSetBranch(0),
             Op::Branch(7),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::Yield(Slot::Local(1)),
+            Op::Yield(1),
             Op::Finish,
         ],
     };
@@ -342,7 +344,8 @@ fn should_branch_on_finished_coroutine_in_resumed_coroutine_where_parent_has_act
             Op::Call(2, vec![]),
             Op::Call(1, vec![]),
             Op::Resume(1),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(0),
         ],
     };
 

--- a/tests/branch.rs
+++ b/tests/branch.rs
@@ -33,15 +33,15 @@ fn should_branch() {
             Op::Gen(S, vec![]), 
             Op::Branch(4),         
             Op::Gen(P, vec![0]),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
 
             Op::Gen(U, vec![]),
             Op::Branch(8),         
             Op::Gen(P, vec![1]),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
 
             Op::Gen(P, vec![0]),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -88,7 +88,7 @@ fn should_loop() {
             Op::Drop(3),
             Op::Gen(SET, vec![]),
             Op::Branch(3), 
-            Op::ReturnSlot(1),
+            Op::ReturnLocal(1),
         ],
     };
 
@@ -124,7 +124,7 @@ fn should_not_branch_on_active_coroutine() {
             Op::Branch(4),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -158,7 +158,7 @@ fn should_branch_on_finished_coroutine() {
             Op::Branch(4),
             Op::Gen(0, vec![0]),
             Op::Gen(0, vec![1]),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -196,7 +196,7 @@ fn should_branch_on_finished_coroutine_with_active_coroutine_present() {
             Op::Branch(6),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -233,7 +233,7 @@ fn should_branch_on_finished_coroutine_in_function_where_parent_has_active_corou
             Op::Branch(5),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -243,7 +243,7 @@ fn should_branch_on_finished_coroutine_in_function_where_parent_has_active_corou
             Op::Call(2, vec![]),
             Op::Call(1, vec![]),
             Op::PushRet,
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -281,7 +281,7 @@ fn should_branch_on_finished_coroutine_in_dyn_function_where_parent_has_active_c
             Op::Branch(5),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -294,7 +294,7 @@ fn should_branch_on_finished_coroutine_in_dyn_function_where_parent_has_active_c
             Op::DynCall(vec![]),
             Op::Call(1, vec![]),
             Op::PushRet,
-            Op::ReturnSlot(1),
+            Op::ReturnLocal(1),
         ],
     };
 
@@ -345,7 +345,7 @@ fn should_branch_on_finished_coroutine_in_resumed_coroutine_where_parent_has_act
             Op::Call(1, vec![]),
             Op::Resume(1),
             Op::PushRet,
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 

--- a/tests/call.rs
+++ b/tests/call.rs
@@ -35,7 +35,8 @@ fn should_dynamic_call() {
         instrs: vec![
             Op::Gen(PUSH_FROM_GLOBAL, vec![1]), // get 2
             Op::Gen(ADD, vec![0, 1]),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(2),
         ],
     };
 
@@ -44,7 +45,8 @@ fn should_dynamic_call() {
         instrs: vec![
             Op::Gen(PUSH_FROM_GLOBAL, vec![0]), // get 1
             Op::Gen(ADD, vec![0, 1]),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(2),
         ],
     };
 
@@ -54,13 +56,14 @@ fn should_dynamic_call() {
             Op::Gen(PUSH_FROM_GLOBAL, vec![2]), // get 7 (now local 0)
             Op::Gen(PUSH_FROM_GLOBAL, vec![3]), // get 17 (now local 1)
             Op::Gen(ONE, vec![]),
-            Op::DynCall(vec![Slot::Local(0)]), // should add 1 to 7 
+            Op::DynCall(vec![0]), // should add 1 to 7 
             Op::PushRet,                       // local 2 is now 8
             Op::Gen(TWO, vec![]),
-            Op::DynCall(vec![Slot::Local(1)]), // should add 2 to 17 
+            Op::DynCall(vec![1]), // should add 2 to 17 
             Op::PushRet,                       // local 3 is now 19
             Op::Gen(ADD, vec![2, 3]),          // should add 19 to 8
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(4),
         ],
     };
 
@@ -93,12 +96,13 @@ fn should_handle_multiple_calls() {
             Op::Gen(DEC, vec![0]),
             Op::PushRet,
             Op::Gen(BZ, vec![1]),
-            Op::Branch(8),
-            Op::Call(1, vec![Slot::Local(1)]),
+            Op::Branch(9),
+            Op::Call(1, vec![1]),
             Op::PushRet,
             Op::Gen(MUL, vec![0, 2]),
-            Op::ReturnSlot(Slot::Return),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::PushRet,
+            Op::ReturnSlot(3),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -106,8 +110,9 @@ fn should_handle_multiple_calls() {
         name: "main".into(),
         instrs: vec![
             Op::Gen(PUSH_FROM_GLOBAL, vec![0]),
-            Op::Call(1, vec![Slot::Local(0)]),
-            Op::ReturnSlot(Slot::Return),
+            Op::Call(1, vec![0]),
+            Op::PushRet,
+            Op::ReturnSlot(1),
         ],
     };
 
@@ -147,9 +152,9 @@ fn should_return() {
         instrs: vec![
             Op::Gen(FROM_G, vec![1]),
             Op::Gen(FROM_G, vec![2]),
-            Op::Call(1, vec![Slot::Local(0), Slot::Local(1)]),
-            Op::Gen(FROM_G, vec![3]),       // from global slot 3
-            Op::ReturnSlot(Slot::Local(2)), // from local slot 2
+            Op::Call(1, vec![0, 1]),
+            Op::Gen(FROM_G, vec![3]),  // from global slot 3
+            Op::ReturnSlot(2),         // from local slot 2
         ],
     };
 
@@ -174,8 +179,8 @@ fn should_order_params() {
         instrs: vec![
             Op::Gen(1, vec![2]),
             Op::Branch(3),
-            Op::ReturnSlot(Slot::Local(0)),
-            Op::ReturnSlot(Slot::Local(1)),
+            Op::ReturnSlot(0),
+            Op::ReturnSlot(1),
         ],
     };
 
@@ -185,8 +190,9 @@ fn should_order_params() {
             Op::Gen(0, vec![0]),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::Call(1, vec![Slot::Local(2), Slot::Local(1), Slot::Local(0)]), // other(5, 3, 0)
-            Op::ReturnSlot(Slot::Return),
+            Op::Call(1, vec![2, 1, 0]), // other(5, 3, 0)
+            Op::PushRet,
+            Op::ReturnSlot(3),
         ],
     };
 
@@ -214,7 +220,8 @@ fn should_order_params_with_dyn_call() {
             Op::Gen(2, vec![0, 1]), // 3 + 5
             Op::PushRet,
             Op::Gen(3, vec![3, 2]), // 8 * 7
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(4),
         ],
     };
 
@@ -226,8 +233,9 @@ fn should_order_params_with_dyn_call() {
             Op::Gen(0, vec![3]),
             Op::Gen(0, vec![0]),
             Op::Gen(1, vec![3]),
-            Op::DynCall(vec![Slot::Local(0), Slot::Local(1), Slot::Local(2)]), // other(3, 5, 7)
-            Op::ReturnSlot(Slot::Return),
+            Op::DynCall(vec![0, 1, 2]), // other(3, 5, 7)
+            Op::PushRet,
+            Op::ReturnSlot(4),
         ],
     };
 
@@ -253,7 +261,8 @@ fn should_call_with_params() {
             Op::Gen(1, vec![0, 1]),
             Op::PushRet,
             Op::Gen(1, vec![2, 3]),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(4),
         ],
     };
 
@@ -263,8 +272,9 @@ fn should_call_with_params() {
             Op::Gen(0, vec![0]),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::Call(1, vec![Slot::Local(0), Slot::Local(1), Slot::Local(2)]),
-            Op::ReturnSlot(Slot::Return),
+            Op::Call(1, vec![0, 1, 2]),
+            Op::PushRet,
+            Op::ReturnSlot(3),
         ],
     };
 
@@ -294,7 +304,7 @@ fn should_call_and_return() {
         name : "ret_nine".into(),
         instrs: vec![
             Op::Gen(0, vec![]),
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -302,7 +312,8 @@ fn should_call_and_return() {
         name: "main".into(),
         instrs: vec![
             Op::Call(1, vec![]),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(0),
         ],
     };
 

--- a/tests/call.rs
+++ b/tests/call.rs
@@ -36,7 +36,7 @@ fn should_dynamic_call() {
             Op::Gen(PUSH_FROM_GLOBAL, vec![1]), // get 2
             Op::Gen(ADD, vec![0, 1]),
             Op::PushRet,
-            Op::ReturnSlot(2),
+            Op::ReturnLocal(2),
         ],
     };
 
@@ -46,7 +46,7 @@ fn should_dynamic_call() {
             Op::Gen(PUSH_FROM_GLOBAL, vec![0]), // get 1
             Op::Gen(ADD, vec![0, 1]),
             Op::PushRet,
-            Op::ReturnSlot(2),
+            Op::ReturnLocal(2),
         ],
     };
 
@@ -56,14 +56,14 @@ fn should_dynamic_call() {
             Op::Gen(PUSH_FROM_GLOBAL, vec![2]), // get 7 (now local 0)
             Op::Gen(PUSH_FROM_GLOBAL, vec![3]), // get 17 (now local 1)
             Op::Gen(ONE, vec![]),
-            Op::DynCall(vec![0]), // should add 1 to 7 
+            Op::DynCall(vec![0]),              // should add 1 to 7 
             Op::PushRet,                       // local 2 is now 8
             Op::Gen(TWO, vec![]),
-            Op::DynCall(vec![1]), // should add 2 to 17 
+            Op::DynCall(vec![1]),              // should add 2 to 17 
             Op::PushRet,                       // local 3 is now 19
             Op::Gen(ADD, vec![2, 3]),          // should add 19 to 8
             Op::PushRet,
-            Op::ReturnSlot(4),
+            Op::ReturnLocal(4),
         ],
     };
 
@@ -101,8 +101,8 @@ fn should_handle_multiple_calls() {
             Op::PushRet,
             Op::Gen(MUL, vec![0, 2]),
             Op::PushRet,
-            Op::ReturnSlot(3),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(3),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -112,7 +112,7 @@ fn should_handle_multiple_calls() {
             Op::Gen(PUSH_FROM_GLOBAL, vec![0]),
             Op::Call(1, vec![0]),
             Op::PushRet,
-            Op::ReturnSlot(1),
+            Op::ReturnLocal(1),
         ],
     };
 
@@ -154,7 +154,7 @@ fn should_return() {
             Op::Gen(FROM_G, vec![2]),
             Op::Call(1, vec![0, 1]),
             Op::Gen(FROM_G, vec![3]),  // from global slot 3
-            Op::ReturnSlot(2),         // from local slot 2
+            Op::ReturnLocal(2),        // from local slot 2
         ],
     };
 
@@ -179,8 +179,8 @@ fn should_order_params() {
         instrs: vec![
             Op::Gen(1, vec![2]),
             Op::Branch(3),
-            Op::ReturnSlot(0),
-            Op::ReturnSlot(1),
+            Op::ReturnLocal(0),
+            Op::ReturnLocal(1),
         ],
     };
 
@@ -192,7 +192,7 @@ fn should_order_params() {
             Op::Gen(0, vec![2]),
             Op::Call(1, vec![2, 1, 0]), // other(5, 3, 0)
             Op::PushRet,
-            Op::ReturnSlot(3),
+            Op::ReturnLocal(3),
         ],
     };
 
@@ -221,7 +221,7 @@ fn should_order_params_with_dyn_call() {
             Op::PushRet,
             Op::Gen(3, vec![3, 2]), // 8 * 7
             Op::PushRet,
-            Op::ReturnSlot(4),
+            Op::ReturnLocal(4),
         ],
     };
 
@@ -235,7 +235,7 @@ fn should_order_params_with_dyn_call() {
             Op::Gen(1, vec![3]),
             Op::DynCall(vec![0, 1, 2]), // other(3, 5, 7)
             Op::PushRet,
-            Op::ReturnSlot(4),
+            Op::ReturnLocal(4),
         ],
     };
 
@@ -262,7 +262,7 @@ fn should_call_with_params() {
             Op::PushRet,
             Op::Gen(1, vec![2, 3]),
             Op::PushRet,
-            Op::ReturnSlot(4),
+            Op::ReturnLocal(4),
         ],
     };
 
@@ -274,7 +274,7 @@ fn should_call_with_params() {
             Op::Gen(0, vec![2]),
             Op::Call(1, vec![0, 1, 2]),
             Op::PushRet,
-            Op::ReturnSlot(3),
+            Op::ReturnLocal(3),
         ],
     };
 
@@ -304,7 +304,7 @@ fn should_call_and_return() {
         name : "ret_nine".into(),
         instrs: vec![
             Op::Gen(0, vec![]),
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -313,7 +313,7 @@ fn should_call_and_return() {
         instrs: vec![
             Op::Call(1, vec![]),
             Op::PushRet,
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 

--- a/tests/coroutine.rs
+++ b/tests/coroutine.rs
@@ -113,7 +113,9 @@ fn should_handle_params() {
             Op::PushRet,
             Op::Resume(0),
             Op::PushRet,
-            Op::ReturnSlot(1), // TODO
+            Op::Gen(2, vec![1, 0]),
+            Op::PushRet,
+            Op::ReturnSlot(2), 
         ],
     };
 
@@ -125,7 +127,7 @@ fn should_handle_params() {
 
     let data = vm.run(0).unwrap().unwrap();
 
-    assert_eq!(data, 56);
+    assert_eq!(data, 448);
 }
 
 #[test]
@@ -164,7 +166,9 @@ fn should_handle_dyn_call_params() {
             Op::PushRet,
             Op::Resume(0),
             Op::PushRet,
-            Op::ReturnSlot(1), // TODO
+            Op::Gen(2, vec![0, 1]),
+            Op::PushRet,
+            Op::ReturnSlot(2), 
         ],
     };
 
@@ -176,7 +180,7 @@ fn should_handle_dyn_call_params() {
 
     let data = vm.run(0).unwrap().unwrap();
 
-    assert_eq!(data, 56);
+    assert_eq!(data, 448);
 }
 
 // TODO 

--- a/tests/coroutine.rs
+++ b/tests/coroutine.rs
@@ -22,7 +22,7 @@ fn should_yield() {
         instrs: vec![
             Op::Call(1, vec![]),
             Op::PushRet,
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -66,7 +66,7 @@ fn should_resume() {
             Op::PushRet,
             Op::Gen(1, vec![0, 1]),
             Op::PushRet,
-            Op::ReturnSlot(2),
+            Op::ReturnLocal(2),
         ],
     };
 
@@ -115,7 +115,7 @@ fn should_handle_params() {
             Op::PushRet,
             Op::Gen(2, vec![1, 0]),
             Op::PushRet,
-            Op::ReturnSlot(2), 
+            Op::ReturnLocal(2), 
         ],
     };
 
@@ -168,7 +168,7 @@ fn should_handle_dyn_call_params() {
             Op::PushRet,
             Op::Gen(2, vec![0, 1]),
             Op::PushRet,
-            Op::ReturnSlot(2), 
+            Op::ReturnLocal(2), 
         ],
     };
 

--- a/tests/coroutine.rs
+++ b/tests/coroutine.rs
@@ -12,7 +12,7 @@ fn should_yield() {
         name: "co".into(),
         instrs: vec![
             Op::Gen(0, vec![0]),
-            Op::Yield(Slot::Local(0)),
+            Op::Yield(0),
             Op::Finish,
         ],
     };
@@ -21,7 +21,8 @@ fn should_yield() {
         name: "main".into(),
         instrs: vec![
             Op::Call(1, vec![]),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -47,10 +48,11 @@ fn should_resume() {
             Op::Gen(0, vec![0]),
             Op::Gen(1, vec![0, 0]),
             Op::PushRet,
-            Op::Yield(Slot::Local(0)),
+            Op::Yield(0),
             Op::Gen(0, vec![0]),
             Op::Gen(1, vec![1, 2]),
-            Op::Yield(Slot::Return),
+            Op::PushRet,
+            Op::Yield(3),
             Op::Finish,
         ],
     };
@@ -63,7 +65,8 @@ fn should_resume() {
             Op::Resume(0),
             Op::PushRet,
             Op::Gen(1, vec![0, 1]),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(2),
         ],
     };
 
@@ -89,9 +92,10 @@ fn should_handle_params() {
         instrs: vec![
             Op::Gen(1, vec![0, 1]),
             Op::PushRet,
-            Op::Yield(Slot::Local(3)),
+            Op::Yield(3),
             Op::Gen(2, vec![3, 2]),
-            Op::Yield(Slot::Return),
+            Op::PushRet,
+            Op::Yield(4),
             Op::Finish,
         ],
     };
@@ -102,13 +106,14 @@ fn should_handle_params() {
             Op::Gen(0, vec![0]),
             Op::Gen(0, vec![1]),
             Op::Gen(0, vec![2]),
-            Op::Call(1, vec![Slot::Local(0), Slot::Local(1), Slot::Local(2)]),
+            Op::Call(1, vec![0, 1, 2]),
             Op::Drop(0),
             Op::Drop(0),
             Op::Drop(0),
             Op::PushRet,
             Op::Resume(0),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(1), // TODO
         ],
     };
 
@@ -135,9 +140,10 @@ fn should_handle_dyn_call_params() {
         instrs: vec![
             Op::Gen(1, vec![0, 1]),
             Op::PushRet,
-            Op::Yield(Slot::Local(3)),
+            Op::Yield(3),
             Op::Gen(2, vec![3, 2]),
-            Op::Yield(Slot::Return),
+            Op::PushRet,
+            Op::Yield(4),
             Op::Finish,
         ],
     };
@@ -150,14 +156,15 @@ fn should_handle_dyn_call_params() {
             Op::Gen(0, vec![2]),
             Op::Gen(0, vec![3]),
             Op::Gen(3, vec![0]),
-            Op::DynCall(vec![Slot::Local(1), Slot::Local(2), Slot::Local(3)]),
+            Op::DynCall(vec![1, 2, 3]),
             Op::Drop(0),
             Op::Drop(0),
             Op::Drop(0),
             Op::Drop(0),
             Op::PushRet,
             Op::Resume(0),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(1), // TODO
         ],
     };
 

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -19,7 +19,8 @@ fn should_swap() {
             Op::Swap(0, 3),
             Op::Swap(1, 2),
             Op::Gen(1, vec![3, 2]),
-            Op::ReturnSlot(Slot::Return),
+            Op::PushRet,
+            Op::ReturnSlot(4),
         ],
     };
 
@@ -43,7 +44,7 @@ fn should_dup() {
         instrs: vec![
             Op::Gen(0, vec![0]),
             Op::Dup(0),                      
-            Op::ReturnSlot(Slot::Local(1)),
+            Op::ReturnSlot(1),
         ],
     };
 
@@ -68,7 +69,7 @@ fn should_drop() {
             Op::Gen(0, vec![0]), // push 3
             Op::Drop(0),         // clear 3 
             Op::Gen(0, vec![1]), // push 7
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -91,7 +92,7 @@ fn should_push_return() {
         name: "one".into(),
         instrs: vec![
             Op::Gen(0, vec![0]), 
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 
@@ -100,7 +101,7 @@ fn should_push_return() {
         instrs: vec![
             Op::Call(1, vec![]),
             Op::PushRet,
-            Op::ReturnSlot(Slot::Local(0)),
+            Op::ReturnSlot(0),
         ],
     };
 

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -20,7 +20,7 @@ fn should_swap() {
             Op::Swap(1, 2),
             Op::Gen(1, vec![3, 2]),
             Op::PushRet,
-            Op::ReturnSlot(4),
+            Op::ReturnLocal(4),
         ],
     };
 
@@ -44,7 +44,7 @@ fn should_dup() {
         instrs: vec![
             Op::Gen(0, vec![0]),
             Op::Dup(0),                      
-            Op::ReturnSlot(1),
+            Op::ReturnLocal(1),
         ],
     };
 
@@ -69,7 +69,7 @@ fn should_drop() {
             Op::Gen(0, vec![0]), // push 3
             Op::Drop(0),         // clear 3 
             Op::Gen(0, vec![1]), // push 7
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -92,7 +92,7 @@ fn should_push_return() {
         name: "one".into(),
         instrs: vec![
             Op::Gen(0, vec![0]), 
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 
@@ -101,7 +101,7 @@ fn should_push_return() {
         instrs: vec![
             Op::Call(1, vec![]),
             Op::PushRet,
-            Op::ReturnSlot(0),
+            Op::ReturnLocal(0),
         ],
     };
 


### PR DESCRIPTION
Slot makes the code more complicated and all of the programs that could be written with a Slot::Return could instead be written with a combination with Op::PushRet and Slot::Local.  Might as well just transition to using usize.

Additionally, while Slot::Return makes for easier programs written by hand, most automatically written programs will probably not make use of this feature because it relies on noticing context which implies a more complex compiler than if transforms always pushed to local and then used that result.

The alternative could be to also drop Op::PushRet and have programs use Op::Drop and then ReturnLocal and Yield would automatically push to local.  However, PushRet fails loudly if you happen to use it for a method that didn't return anything.  On the other hand if you Drop a method that didn't return anything (which you expected to auto push), then it might work just fine because something was already in locals.
