### PR TITLE
Refactor how GenOp works

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -41,6 +41,7 @@ pub struct VmEnv<'a, T, S> {
     pub current : &'a mut Frame<T>,
 }
 
+// TODO add gen op tests for each of these items
 pub enum GenOp<T, S> {
     Vm { name : Rc<str>, op : for<'a> fn(vm : VmEnv<'a, T, S>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> },
     Global { name : Rc<str>, op : fn(globals : &mut Vec<S>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> },

--- a/src/data.rs
+++ b/src/data.rs
@@ -41,7 +41,6 @@ pub struct VmEnv<'a, T, S> {
     pub current : &'a mut Frame<T>,
 }
 
-// TODO add gen op tests for each of these items
 pub enum GenOp<T, S> {
     Vm { name : Rc<str>, op : for<'a> fn(vm : VmEnv<'a, T, S>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> },
     Global { name : Rc<str>, op : fn(globals : &mut Vec<S>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> },

--- a/src/data.rs
+++ b/src/data.rs
@@ -48,3 +48,21 @@ pub struct GenOp<T, S> {
     // TODO Global op, Local op, Frame op, Vm op
     pub op : for<'a> fn(env : OpEnv<'a, T, S>, params : &Vec<usize>) -> Result<(), Box<dyn std::error::Error>>,
 }
+
+#[derive(Clone)]
+pub struct Frame<T> {
+    pub (crate) fun_id : usize,
+    pub (crate) ip : usize,
+    pub (crate) ret : Option<T>,
+    pub branch : bool,
+    pub dyn_call : Option<usize>,
+    pub locals : Vec<T>,
+    pub coroutines : Vec<Coroutine<T>>,
+}
+
+#[derive(Clone)]
+pub enum Coroutine<T> {
+    Active(Frame<T>),
+    Running,
+    Finished,
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -35,15 +35,6 @@ pub struct Fun<T> {
     pub instrs : Vec<Op<T>>,
 }
 
-// TODO see if this can be replaced with Frame which will need to be moved to data
-pub struct OpEnv<'a, T, S> {
-    pub locals : &'a mut Vec<T>,
-    pub globals : &'a mut Vec<S>,
-    pub ret : &'a mut Option<T>,
-    pub branch : &'a mut bool,
-    pub dyn_call : &'a mut Option<usize>,
-}
-
 pub struct VmEnv<'a, T, S> {
     pub globals: &'a mut Vec<S>,
     pub frames : &'a mut Vec<Frame<T>>,
@@ -51,12 +42,10 @@ pub struct VmEnv<'a, T, S> {
 }
 
 pub enum GenOp<T, S> {
-    Vm { name : Rc<str>, op : for<'a> fn(vm : VmEnv<'a, T, S>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> }
-    /*pub name : Box<str>,
-    // TODO maybe &vec<_> => &[]
-    // TODO Global op, Local op, Frame op, Vm op
-    pub op : for<'a> fn(env : OpEnv<'a, T, S>, params : &Vec<usize>) -> Result<(), Box<dyn std::error::Error>>,
-    */
+    Vm { name : Rc<str>, op : for<'a> fn(vm : VmEnv<'a, T, S>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> },
+    Global { name : Rc<str>, op : fn(globals : &mut Vec<S>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> },
+    Local { name : Rc<str>, op : fn(locals : &mut Vec<T>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> },
+    Frame { name : Rc<str>, op : fn(frame : &mut Frame<T>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> },
 }
 
 #[derive(Clone)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,6 +5,8 @@
 
 // TODO does frame allow lambda impl?
 
+use std::rc::Rc;
+
 pub enum Op<T> {
     Gen(usize, Vec<usize>),
     Call(usize, Vec<usize>),
@@ -42,11 +44,19 @@ pub struct OpEnv<'a, T, S> {
     pub dyn_call : &'a mut Option<usize>,
 }
 
-pub struct GenOp<T, S> {
-    pub name : Box<str>,
+pub struct VmEnv<'a, T, S> {
+    pub globals: &'a mut Vec<S>,
+    pub frames : &'a mut Vec<Frame<T>>,
+    pub current : &'a mut Frame<T>,
+}
+
+pub enum GenOp<T, S> {
+    Vm { name : Rc<str>, op : for<'a> fn(vm : VmEnv<'a, T, S>, params : &[usize]) -> Result<Option<T>, Box<dyn std::error::Error>> }
+    /*pub name : Box<str>,
     // TODO maybe &vec<_> => &[]
     // TODO Global op, Local op, Frame op, Vm op
     pub op : for<'a> fn(env : OpEnv<'a, T, S>, params : &Vec<usize>) -> Result<(), Box<dyn std::error::Error>>,
+    */
 }
 
 #[derive(Clone)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,6 @@
 
+use std::rc::Rc;
+
 pub type StackTrace = Vec<(Box<str>, usize)>;
 
 #[derive(Debug)]
@@ -9,7 +11,7 @@ pub enum VmError {
     GenOpDoesNotExist(usize, StackTrace),
     AccessMissingReturn(StackTrace),
     AccessMissingLocal(usize, StackTrace),
-    GenOpError(Box<str>, Box<dyn std::error::Error>, StackTrace),
+    GenOpError(Rc<str>, Box<dyn std::error::Error>, StackTrace),
     TopLevelYield(usize),
     AccessMissingCoroutine(usize, StackTrace),
     ResumeFinishedCoroutine(usize, StackTrace),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,31 +7,12 @@ use crate::data::*;
 
 use std::borrow::Cow;
 
-
 pub struct Vm<T, S> {
     funs : Vec<Fun<T>>,
     ops : Vec<GenOp<T, S>>,
-    globals: Vec<S>,
-    frames : Vec<Frame<T>>,
-    current : Frame<T>,
-}
-
-#[derive(Clone)]
-struct Frame<T> {
-    fun_id : usize,
-    ip : usize,
-    ret : Option<T>,
-    branch : bool,
-    dyn_call : Option<usize>,
-    locals : Vec<T>,
-    coroutines : Vec<Coroutine<T>>,
-}
-
-#[derive(Clone)]
-enum Coroutine<T> {
-    Active(Frame<T>),
-    Running,
-    Finished,
+    pub globals: Vec<S>,
+    pub frames : Vec<Frame<T>>,
+    pub current : Frame<T>,
 }
 
 impl<T : Clone, S> Vm<T, S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,6 @@ fn get_local<T : Clone>(index: usize, locals : Cow<Vec<T>>) -> Result<T, Box<dyn
     }
 }
 
-
 fn co_is_running<T>(coroutine : &Coroutine<T>) -> bool {
     match coroutine { 
         Coroutine::Running => true,

--- a/tests/branch.rs
+++ b/tests/branch.rs
@@ -14,16 +14,16 @@ fn should_branch() {
     let set_branch: GenOp<u8, u8> = common::gen_set_branch();
     let unset_branch: GenOp<u8, u8> = common::gen_unset_branch();
 
-    let push_stack : GenOp<u8, u8> = GenOp {
+    let push_stack : GenOp<u8, u8> = GenOp::Local {
         name : "push".into(),
-        op: |env, ps | { 
+        op: |locals, ps | { 
             if ps[0] == 0 {
-                env.locals.push(0);
+                locals.push(0);
             }
             if ps[0] == 1 {
-                env.locals.push(1);
+                locals.push(1);
             }
-            Ok(())
+            Ok(None)
         },
     };
 

--- a/tests/call.rs
+++ b/tests/call.rs
@@ -14,19 +14,19 @@ fn should_dynamic_call() {
     let add = common::gen_add();
     let push_from_global = common::gen_push_global();
 
-    let set_dyn_call_two = GenOp { 
+    let set_dyn_call_two = GenOp::Frame { 
         name: "set two".into(),
-        op: | env, _ | {
-            *env.dyn_call = Some(2);
-            Ok(())
+        op: | frame, _ | {
+            frame.dyn_call = Some(2);
+            Ok(None)
         },
     };
 
-    let set_dyn_call_one = GenOp { 
+    let set_dyn_call_one = GenOp::Frame { 
         name: "set one".into(),
-        op: | env, _ | {
-            *env.dyn_call = Some(1);
-            Ok(())
+        op: | frame, _ | {
+            frame.dyn_call = Some(1);
+            Ok(None)
         },
     };
 
@@ -292,11 +292,11 @@ fn should_call_with_params() {
 #[test]
 fn should_call_and_return() {
 
-    let push : GenOp<u8, u8> = GenOp {
+    let push : GenOp<u8, u8> = GenOp::Local {
         name : "push".into(),
-        op: |env, _ | { 
-            env.locals.push(9);
-            Ok(())
+        op: |locals, _ | { 
+            locals.push(9);
+            Ok(None)
         },
     };
 

--- a/tests/gen_op.rs
+++ b/tests/gen_op.rs
@@ -6,6 +6,135 @@ use an_a_vm::data::*;
 use an_a_vm::error::*;
 
 #[test]
+fn should_modify_global() {
+    let op = GenOp::Global {
+        name: "op".into(),
+        op: | globals, params |  { 
+            globals[params[0]] += 1;
+            Ok(None)
+        },
+    };
+
+    let ret_glob = GenOp::Global {
+        name: "ret_glob".into(),
+        op: | globals, _params | {
+            Ok(Some(globals[1]))
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![1]),
+            Op::Gen(1, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op, ret_glob]);
+
+    vm.with_globals(vec![0, 3]);
+
+    let data = vm.run(0).unwrap().unwrap();
+
+    assert_eq!(data, 4);
+}
+
+#[test]
+fn should_push_global() {
+
+    let op = GenOp::Global {
+        name: "op".into(),
+        op: | globals, _params |  { 
+            globals.push(3);
+            Ok(None)
+        },
+    };
+
+    let ret_glob = GenOp::Global {
+        name: "ret_glob".into(),
+        op: | globals, _params | {
+            Ok(Some(globals[0]))
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::Gen(1, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op, ret_glob]);
+
+    let data = vm.run(0).unwrap().unwrap();
+
+    assert_eq!(data, 3);
+}
+
+#[test]
+fn should_not_return_from_global() {
+    let op = GenOp::Global {
+        name: "op".into(),
+        op: | _globals, _params |  { 
+            Ok(None)
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let error = vm.run(0);
+
+    assert!(matches!(error, Err(VmError::AccessMissingReturn(_))));
+}
+
+#[test]
+fn should_return_from_global() {
+    let op = GenOp::Global {
+        name: "op".into(),
+        op: | _globals, _params |  { 
+            Ok(Some(3))
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let data = vm.run(0).unwrap().unwrap();
+
+    assert_eq!(data, 3);
+}
+
+#[test]
 fn should_modify_local() {
     let op = GenOp::Local {
         name: "op".into(),

--- a/tests/gen_op.rs
+++ b/tests/gen_op.rs
@@ -243,3 +243,114 @@ fn should_return_from_local() {
 
     assert_eq!(data, 3);
 }
+
+// frame
+#[test]
+fn should_not_return_from_frame() {
+    let op = GenOp::Frame {
+        name: "op".into(),
+        op: | _frame, _params |  { 
+            Ok(None)
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let error = vm.run(0);
+
+    assert!(matches!(error, Err(VmError::AccessMissingReturn(_))));
+}
+
+#[test]
+fn should_return_from_frame() {
+    let op = GenOp::Frame {
+        name: "op".into(),
+        op: | _frame, _params |  { 
+            Ok(Some(3))
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let data = vm.run(0).unwrap().unwrap();
+
+    assert_eq!(data, 3);
+}
+
+// VM
+
+#[test]
+fn should_not_return_from_vm() {
+    let op = GenOp::Vm {
+        name: "op".into(),
+        op: | _frame, _params |  { 
+            Ok(None)
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let error = vm.run(0);
+
+    assert!(matches!(error, Err(VmError::AccessMissingReturn(_))));
+}
+
+#[test]
+fn should_return_from_vm() {
+    let op = GenOp::Vm{
+        name: "op".into(),
+        op: | _frame, _params |  { 
+            Ok(Some(3))
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let data = vm.run(0).unwrap().unwrap();
+
+    assert_eq!(data, 3);
+}

--- a/tests/gen_op.rs
+++ b/tests/gen_op.rs
@@ -244,7 +244,6 @@ fn should_return_from_local() {
     assert_eq!(data, 3);
 }
 
-// frame
 #[test]
 fn should_not_return_from_frame() {
     let op = GenOp::Frame {
@@ -298,8 +297,6 @@ fn should_return_from_frame() {
 
     assert_eq!(data, 3);
 }
-
-// VM
 
 #[test]
 fn should_not_return_from_vm() {

--- a/tests/gen_op.rs
+++ b/tests/gen_op.rs
@@ -6,6 +6,62 @@ use an_a_vm::data::*;
 use an_a_vm::error::*;
 
 #[test]
+fn should_modify_local() {
+    let op = GenOp::Local {
+        name: "op".into(),
+        op: | locals, params |  { 
+            locals[params[0]] += 1;
+            Ok(None)
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::PushLocal(0),
+            Op::PushLocal(3),
+            Op::Gen(0, vec![1]),
+            Op::ReturnLocal(1),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let data = vm.run(0).unwrap().unwrap();
+
+    assert_eq!(data, 4);
+}
+
+#[test]
+fn should_push_local() {
+    let op = GenOp::Local {
+        name: "op".into(),
+        op: | locals, _params |  { 
+            locals.push(3);
+            Ok(None)
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let data = vm.run(0).unwrap().unwrap();
+
+    assert_eq!(data, 3);
+}
+
+#[test]
 fn should_not_return_from_local() {
     let op = GenOp::Local {
         name: "op".into(),

--- a/tests/gen_op.rs
+++ b/tests/gen_op.rs
@@ -1,0 +1,32 @@
+
+pub mod common;
+
+use an_a_vm::*;
+use an_a_vm::data::*;
+
+#[test]
+fn should_return_from_local() {
+    let op = GenOp::Local {
+        name: "op".into(),
+        op: | locals, params |  { 
+            Ok(Some(3))
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let data = vm.run(0).unwrap().unwrap();
+
+    assert_eq!(data, 3);
+}

--- a/tests/gen_op.rs
+++ b/tests/gen_op.rs
@@ -3,12 +3,40 @@ pub mod common;
 
 use an_a_vm::*;
 use an_a_vm::data::*;
+use an_a_vm::error::*;
+
+#[test]
+fn should_not_return_from_local() {
+    let op = GenOp::Local {
+        name: "op".into(),
+        op: | _locals, _params |  { 
+            Ok(None)
+        },
+    };
+
+    let main = Fun {
+        name: "main".into(),
+        instrs: vec![
+            Op::Gen(0, vec![]),
+            Op::PushRet,
+            Op::ReturnLocal(0),
+        ],
+    };
+
+    let mut vm : Vm<usize, usize> = Vm::new( 
+        vec![main],
+        vec![op]);
+
+    let error = vm.run(0);
+
+    assert!(matches!(error, Err(VmError::AccessMissingReturn(_))));
+}
 
 #[test]
 fn should_return_from_local() {
     let op = GenOp::Local {
         name: "op".into(),
-        op: | locals, params |  { 
+        op: | _locals, _params |  { 
             Ok(Some(3))
         },
     };


### PR DESCRIPTION
Adds Local, Global, Frame, and VM Generic Opcodes.  So any given opcode can be limited in scope to what it's doing.